### PR TITLE
Reduced warning option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ endif()
 file (GLOB_RECURSE ARCH_FILES src/arch/${CSP_ARCH}/*.c)
 target_sources (csp PUBLIC ${ARCH_FILES})
 
-target_compile_options(csp PUBLIC -O2 -Wall -g -std=gnu99)
+target_compile_options(csp PUBLIC -O2 -g -std=gnu99)
 
 if (LOGLEVEL STREQUAL "debug")
     set (CSP_LOG_LEVEL_DEBUG ON)


### PR DESCRIPTION
Previously the csp project always compiled with all warnings. This option has been removed in favor of triggering `Wall` from the target build configuration (https://github.com/openkosmosorg/target-kubos-gcc/pull/4).